### PR TITLE
Fix arm64 release artifact upload

### DIFF
--- a/.github/workflows/android-build-release.yml
+++ b/.github/workflows/android-build-release.yml
@@ -87,6 +87,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: bin/32/app-armeabi-v7a-release.apk
+          asset_path: bin/64/app-arm64-v8a-release.apk
           asset_name: boum-${BOUM_VERSION}-arm64.apk
           asset_content_type: application/octet-stream


### PR DESCRIPTION
Closes #6
Previously we would upload the armv7a instead of the armv8a version.