### PR TITLE
Fix: Use the Android native SQLite implementation

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -3,17 +3,5 @@ module.exports = {
     ios: {},
     android: {},
   },
-  dependencies: {
-    'react-native-sqlite-storage': {
-      platforms: {
-        android: {
-          sourceDir:
-            '../node_modules/react-native-sqlite-storage/platforms/android-native',
-          packageImportPath: 'import io.liteglue.SQLitePluginPackage;',
-          packageInstance: 'new SQLitePluginPackage()',
-        },
-      },
-    },
-  },
   assets: ['./app/res/'],
 };


### PR DESCRIPTION
Previously we would use the binary provided by the library, which wouldn't work on arm64. Since we're checking for every track in the db whether it's available on the device, SQLite failing also meant that no tracks were added to the Trackplayer.